### PR TITLE
Add pyyaml as a dependency; used by the samplesheet module

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Python modules:
 * biopython v. 1.70
 * python-levenshtein v. 0.12.0
 * numpy v. 1.19.2
+* pyyaml v. 6.0
 
 Software:
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,8 @@ setup(
     install_requires=[
         'python-levenshtein==0.12.1',
         'biopython==1.79',
-        'numpy==1.22.0'
+        'numpy==1.22.0',
+        'pyyaml==6.0'
     ],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
Adds pyyaml as a dependency, this fixed the Bioconda update at https://github.com/bioconda/bioconda-recipes/pull/39874

The 0.5.0 PyPI version of bio-anglerfish does not work in a clean environment due to this.