### PR TITLE
Changed conda env to development only

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM mambaorg/micromamba
 
 LABEL author="Remi-Andre Olsen" \
-      description="Anglerfish" \
+      description="Anglerfish development version" \
       maintainer="remi-andre.olsen@scilifelab.se"
 
 USER root
@@ -12,5 +12,5 @@ ENV PATH /opt/conda/envs/anglerfish/bin:$PATH
 # Add source files to the container
 ADD . /usr/src/anglerfish
 WORKDIR /usr/src/anglerfish
-RUN eval "$(micromamba shell hook --shell bash)" && micromamba activate anglerfish && python -m pip install .
+RUN eval "$(micromamba shell hook --shell bash)" && micromamba activate anglerfish && python -m pip install .[dev]
 USER $MAMBA_USER

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ cd anglerfish
 # Create a the anglerfish conda environment
 conda env create -f environment.yml
 # Install anglerfish
-conda activate anglerfish
+conda activate anglerfish-dev
 pip install -e ".[dev]"
 ```
 

--- a/README.md
+++ b/README.md
@@ -46,23 +46,16 @@ cd anglerfish
 conda env create -f environment.yml
 # Install anglerfish
 conda activate anglerfish
-pip install -e .
+pip install -e ".[dev]"
 ```
 
-3. Install developer tools
-
-```
-conda install --file requirements-dev-conda.txt
-pip install -r requirements-dev-pip.txt
-```
-
-4. (Optional) Install pre-commit to prevent committing code that will fail linting
+3. (Optional) Install pre-commit to prevent committing code that will fail linting
 
 ```
 pre-commit install
 ```
 
-5. (Optional) Enable automatic formatting in VS Code by creating `.vscode/settings.json` with:
+4. (Optional) Enable automatic formatting in VS Code by creating `.vscode/settings.json` with:
 
 ```
 {

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,5 @@
-name: anglerfish
+# Development environment for anglerfish
+name: anglerfish-dev
 channels:
   - conda-forge
   - bioconda
@@ -8,3 +9,5 @@ dependencies:
   - conda-forge::numpy>=1.22.0
   - bioconda::minimap2=2.20
   - conda-forge::pyyaml=6.0
+  - conda-forge::pre-commit
+  - conda-forge::prettier

--- a/requirements-dev-conda.txt
+++ b/requirements-dev-conda.txt
@@ -1,2 +1,0 @@
-conda-forge::pre-commit
-conda-forge::prettier

--- a/requirements-dev-pip.txt
+++ b/requirements-dev-pip.txt
@@ -1,3 +1,0 @@
-ruff
-mypy
-editorconfig-checker

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         "numpy>=1.22.0",
         "pyyaml==6.0",
     ],
+    extras_require={"dev": ["ruff", "mypy", "editorconfig-checker"]},
     entry_points={
         "console_scripts": [
             "anglerfish=anglerfish.anglerfish:anglerfish",


### PR DESCRIPTION
Anglerfish is currently distributed via PyPI and bioconda so there should be no need for these `environment.yml` and `Dockerfile` relics. 
The separate conda and pip requirement files in #54 started to annoy me so I streamlined them into the conda env and setuptools.